### PR TITLE
dhcp: Add MUD support for DHCPv4 and DHCPv6

### DIFF
--- a/src/core/ipv4/dhcp.c
+++ b/src/core/ipv4/dhcp.c
@@ -224,6 +224,9 @@ static u16_t dhcp_option_long(u16_t options_out_len, u8_t *options, u32_t value)
 #if LWIP_NETIF_HOSTNAME
 static u16_t dhcp_option_hostname(u16_t options_out_len, u8_t *options, struct netif *netif);
 #endif /* LWIP_NETIF_HOSTNAME */
+#if LWIP_DHCP_MUD_URL
+static u16_t dhcp_option_mud_url(u16_t options_out_len, u8_t *options, char *mud_url);
+#endif /* LWIP_DHCP_MUD_URL */
 /* always add the DHCP options trailer to end and pad */
 static void dhcp_option_trailer(u16_t options_out_len, u8_t *options, struct pbuf *p_out);
 
@@ -440,6 +443,11 @@ dhcp_select(struct netif *netif)
 #if LWIP_NETIF_HOSTNAME
     options_out_len = dhcp_option_hostname(options_out_len, msg_out->options, netif);
 #endif /* LWIP_NETIF_HOSTNAME */
+
+
+#if LWIP_DHCP_MUD_URL
+    options_out_len = dhcp_option_mud_url(options_out_len, msg_out->options, LWIP_MUD_URL_STRING);
+#endif /* LWIP_DHCP_MUD_URL */
 
     LWIP_HOOK_DHCP_APPEND_OPTIONS(netif, dhcp, DHCP_STATE_REQUESTING, msg_out, DHCP_REQUEST, &options_out_len);
     dhcp_option_trailer(options_out_len, msg_out->options, p_out);
@@ -1475,6 +1483,31 @@ dhcp_option_hostname(u16_t options_out_len, u8_t *options, struct netif *netif)
   return options_out_len;
 }
 #endif /* LWIP_NETIF_HOSTNAME */
+
+#if LWIP_DHCP_MUD_URL
+static u16_t
+dhcp_option_mud_url(u16_t options_out_len, u8_t *options, char *mud_url)
+{
+  size_t mud_url_len = strlen(mud_url);
+  LWIP_ASSERT("DHCP: MUD URLs must start with https://",
+               strncmp(mud_url, "https://", 8) == 0);
+  if (mud_url_len > 0) {
+    size_t len;
+    const char *p = mud_url;
+    /* Shrink len to available bytes (need 2 bytes for OPTION_MUD_URL
+        and 1 byte for trailer) */
+    size_t available = DHCP_OPTIONS_LEN - options_out_len - 3;
+    LWIP_ASSERT("DHCP: MUD URL is too long!", mud_url_len <= available);
+    len = LWIP_MIN(mud_url_len, available);
+    LWIP_ASSERT("DHCP: MUD URL is too long!", len < 254);
+    options_out_len = dhcp_option(options_out_len, options, DHCP_OPTION_MUD_URL_V4, (u8_t)len);
+    while (len--) {
+      options_out_len = dhcp_option_byte(options_out_len, options, *p++);
+    }
+  }
+  return options_out_len;
+}
+#endif /* LWIP_DHCP_MUD_URL */
 
 /**
  * Extract the DHCP message and the DHCP options.

--- a/src/core/ipv6/dhcp6.c
+++ b/src/core/ipv6/dhcp6.c
@@ -134,6 +134,11 @@ static u8_t dhcp6_pcb_refcount;
 /* receive, unfold, parse and free incoming messages */
 static void dhcp6_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port);
 
+#if LWIP_DHCP6_MUD_URL
+static u16_t dhcp6_option_mud_url(u16_t options_out_len, u8_t *options, char *mud_url, u16_t max_len);
+#endif /* LWIP_DHCP6_MUD_URL */
+
+
 /** Ensure DHCP PCB is allocated and bound */
 static err_t
 dhcp6_inc_pcb_refcount(void)
@@ -412,6 +417,13 @@ dhcp6_create_msg(struct netif *netif, struct dhcp6 *dhcp6, u8_t message_type,
 }
 
 static u16_t
+dhcp6_option_byte(u16_t options_out_len, u8_t *options, u16_t value)
+{
+  options[options_out_len++] = value;
+  return options_out_len;
+}
+
+static u16_t
 dhcp6_option_short(u16_t options_out_len, u8_t *options, u16_t value)
 {
   options[options_out_len++] = (u8_t)((value & 0xff00U) >> 8);
@@ -437,6 +449,31 @@ dhcp6_option_optionrequest(u16_t options_out_len, u8_t *options, const u16_t *re
   }
   return ret;
 }
+
+#if LWIP_DHCP6_MUD_URL
+static u16_t
+dhcp6_option_mud_url(u16_t options_out_len, u8_t *options, char *mud_url, u16_t max_len)
+{
+  size_t i;
+  u16_t ret;
+  size_t mud_url_len = strlen(mud_url);
+
+  LWIP_ASSERT("dhcp6_option_mud_url: options_out_len + sizeof(struct dhcp6_msg) + mud_url_len <= max_len",
+    sizeof(struct dhcp6_msg) + options_out_len + 4U + mud_url_len <= max_len);
+  LWIP_ASSERT("DHCP: MUD URLs must start with https://",
+               strncmp(mud_url, "https://", 8) == 0);
+  LWIP_UNUSED_ARG(max_len);
+
+  LWIP_ASSERT("DHCP: MUD URL is too long!", len < 253);
+  ret = dhcp6_option_short(options_out_len, options, DHCP6_OPTION_MUD_URL_V6);
+  ret = dhcp6_option_short(ret, options, mud_url_len);
+  while (len--) {
+    ret = dhcp_option_byte(ret, options, *p++);
+  }
+
+  return ret;
+}
+#endif /* LWIP_DHCP6_MUD_URL */
 
 /* All options are added, shrink the pbuf to the required size */
 static void
@@ -475,6 +512,11 @@ dhcp6_information_request(struct netif *netif, struct dhcp6 *dhcp6)
 
     options_out_len = dhcp6_option_optionrequest(options_out_len, options, requested_options,
       LWIP_ARRAYSIZE(requested_options), p_out->len);
+
+#if LWIP_DHCP6_MUD_URL
+    options_out_len = dhcp6_option_mud_url(options_out_len, msg_out->options, LWIP_MUD_URL_STRING, p_out->len);
+#endif /* LWIP_DHCP6_MUD_URL */
+
     LWIP_HOOK_DHCP6_APPEND_OPTIONS(netif, dhcp6, DHCP6_STATE_REQUESTING_CONFIG, msg_out,
       DHCP6_INFOREQUEST, options_out_len, p_out->len);
     dhcp6_msg_finalize(options_out_len, p_out);

--- a/src/include/lwip/opt.h
+++ b/src/include/lwip/opt.h
@@ -966,6 +966,13 @@
 #if !defined LWIP_DHCP_MAX_DNS_SERVERS || defined __DOXYGEN__
 #define LWIP_DHCP_MAX_DNS_SERVERS       DNS_MAX_SERVERS
 #endif
+
+/**
+ * LWIP_DHCP_MUD_URL == 1: Emit MUD URL (RFC 8520) via DHCP.
+ */
+#if !defined LWIP_DHCP_MUD_URL || defined __DOXYGEN__
+#define LWIP_DHCP_MUD_URL               0
+#endif
 /**
  * @}
  */

--- a/src/include/lwip/opt.h
+++ b/src/include/lwip/opt.h
@@ -2781,6 +2781,13 @@
 #if !defined LWIP_DHCP6_MAX_DNS_SERVERS || defined __DOXYGEN__
 #define LWIP_DHCP6_MAX_DNS_SERVERS      DNS_MAX_SERVERS
 #endif
+
+/**
+ * LWIP_DHCP6_MUD_URL == 1: Emit MUD URL (RFC 8520) via DHCPv6.
+ */
+#if !defined LWIP_DHCP6_MUD_URL || defined __DOXYGEN__
+#define LWIP_DHCP6_MUD_URL              0
+#endif
 /**
  * @}
  */

--- a/src/include/lwip/prot/dhcp.h
+++ b/src/include/lwip/prot/dhcp.h
@@ -164,6 +164,8 @@ typedef enum {
 #define DHCP_OPTION_TFTP_SERVERNAME 66
 #define DHCP_OPTION_BOOTFILE        67
 
+#define DHCP_OPTION_MUD_URL_V4      116 /* RFC 8520 10., MUD URL Option */
+
 /* possible combinations of overloading the file and sname fields with options */
 #define DHCP_OVERLOAD_NONE          0
 #define DHCP_OVERLOAD_FILE          1

--- a/src/include/lwip/prot/dhcp6.h
+++ b/src/include/lwip/prot/dhcp6.h
@@ -129,6 +129,7 @@ typedef enum {
 #define DHCP6_OPTION_DNS_SERVERS    23 /* RFC 3646 */
 #define DHCP6_OPTION_DOMAIN_LIST    24 /* RFC 3646 */
 #define DHCP6_OPTION_SNTP_SERVERS   31 /* RFC 4075 */
+#define DHCP6_OPTION_MUD_URL_V6     112 /* RFC 8520 */
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
#1 somehow contained unrelated commits, which I somehow couldn't get rid of. This PR supersedes and closes #1, providing a cleaner commit history.